### PR TITLE
Remove AuthZ header from server validation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,15 +11,12 @@ export class FetchError extends Error {
   }
 }
 
-export const validateServerURL = async (mattermostServerURL: string, authToken: string) => {
+export const validateServerURL = async (mattermostServerURL: string) => {
   try {
     let response = await fetch(
       `${mattermostServerURL}/plugins/playbooks/tabapp/runs`,
       {
-        method: 'OPTIONS',
-        headers: {
-          "Authorization": authToken,
-        },
+        method: 'OPTIONS'
       }
     );
 

--- a/src/components/Setup.tsx
+++ b/src/components/Setup.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import MattermostLogo from './mattermost_logo.svg';
-import { getAuthToken } from './auth';
 import { validateServerURL } from '../client';
 
 const styles = {
@@ -83,8 +82,7 @@ export default function Setup() {
         return
       }
 
-      const token = await getAuthToken()
-      const valid = await validateServerURL(url, token)
+      const valid = await validateServerURL(url)
       if (!valid) {
         setErrorText("This server does not appear to be configured for integration with MS Teams. Contact your system administrator.");
         return


### PR DESCRIPTION
#### Summary
There is no change in functionality. I'm only removing the Authorization header from the request doing server validation as this is not needed from the playbooks side and it may confuse future reviewers