### PR TITLE
Use the term Connect instead of Save

### DIFF
--- a/src/components/Setup.tsx
+++ b/src/components/Setup.tsx
@@ -105,7 +105,7 @@ export default function Setup() {
           <input id="urlInput" style={styles.urlInput} value={url} onChange={(event) => setURL(event.target.value)} />
         </div>
         <div style={styles.saveContainer}>
-          <button style={styles.saveButton}>Save</button>
+          <button style={styles.saveButton}>Connect</button>
         </div>
         {errorText.length > 0 &&
           <label id="errorText" className="error">{errorText}</label>


### PR DESCRIPTION
#### Summary
As per feedback from @matthewbirtch, let's change the label on this setup screen's button to read `Connect` instead of `Save`.

#### Ticket Link
None.